### PR TITLE
OakConstraint on AEM install fix

### DIFF
--- a/ui.apps/src/main/content/jcr_root/apps/aemnodemorph/.content.xml
+++ b/ui.apps/src/main/content/jcr_root/apps/aemnodemorph/.content.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jcr:root xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0"
-    jcr:primaryType="nt:unstructured"
+    jcr:primaryType="sling:Folder"
     jcr:title="AEMNodeMorph"/>


### PR DESCRIPTION
Changing from nt:unstructured to sling:Folder to avoid OakConstraint error on AEM package install:

org.apache.jackrabbit.vault.packaging.PackageException: javax.jcr.nodetype.ConstraintViolationException: OakConstraint0001: /apps[[nt:folder, rep:AccessControllable]]: No matching definition found for child node aemnodemorph with effective type [nt:unstructured] (500)